### PR TITLE
Add task for installing Docker

### DIFF
--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -1,0 +1,21 @@
+# Refer to https://docs.docker.com/engine/installation/linux/rhel/
+# and https://docs.docker.com/engine/installation/linux/centos/
+
+- name: Store Docker repository url as a yum variable
+  copy:
+    content: "{{ docker_base_url }}"
+    dest: /etc/yum/vars/dockerurl
+
+- name: Ensure yum-utils is present
+  yum:
+    name: yum-utils
+    state: present
+
+- name: Add the Docker repositories
+  command: yum-config-manager --add-repo {{ docker_repo_url }}
+
+- name: Install the Docker engine
+  yum:
+    name: "{{ docker_edition }}"
+    state: present
+    update_cache: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,6 @@
----
 docker_edition: 'docker-ce'
 docker_base_url: 'https://download.docker.com/linux/centos'
 docker_repo_url: '{{ docker_base_url }}/{{ docker_edition }}.repo'
+
+docker_ce_gpg_fingerprint: '060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35'
+docker_ee_gpg_fingerprint: 'DD91 1E99 5A64 A202 E859 07D6 BC14 F10B 6D08 5F96'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
-# vars file for docker-engine
+docker_edition: 'docker-ce'
+docker_base_url: 'https://download.docker.com/linux/centos'
+docker_repo_url: '{{ docker_base_url }}/{{ docker_edition }}.repo'


### PR DESCRIPTION
The docker-engine task ensures that Docker repo(s) are available and
that the selected Docker package (based on the edition) is present.