### PR TITLE
Add task for configuring direct-lvm mode storage

### DIFF
--- a/tasks/direct-lvm-storage.yml
+++ b/tasks/direct-lvm-storage.yml
@@ -1,0 +1,36 @@
+# Refer to https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/#configure-docker-with-devicemapper
+
+- name: Ensure lvm2 is present
+  yum:
+    name: lvm2
+    state: present
+
+- name: Create volume group
+  lvg:
+    vg: "{{ docker_vg_name }}"
+    pvs: "{{ docker_pvs }}"
+
+- name: Create thinpool logical volume
+  lvol:
+    vg: "{{ docker_vg_name }}"
+    lv: thinpool
+    opts: "--wipesignatures y"
+    size: "{{ docker_thinpool_size }}"
+
+- name: Create thinpoolmeta logical volume
+  lvol:
+    vg: "{{ docker_vg_name }}"
+    lv: thinpoolmeta
+    opts: "--wipesignatures y"
+    size: "{{ docker_thinpoolmeta_size }}"
+
+- name: Convert to thin pool
+  command: "lvconvert -y --zero n -c 512K --thinpool {{ docker_vg_name }}/thinpool --poolmetadata {{ docker_vg_name }}/thinpoolmeta"
+
+- name: Set lvm profile
+  template:
+    src: templates/docker-thinpool.profile
+    dest: "/etc/lvm/profile/{{ docker_vg_name }}-thinpool.profile"
+
+- name: Apply lvm profile
+  command: "lvchange --metadataprofile {{ docker_vg_name }}-thinpool {{ docker_vg_name }}/thinpool"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,3 +4,8 @@ docker_repo_url: '{{ docker_base_url }}/{{ docker_edition }}.repo'
 
 docker_ce_gpg_fingerprint: '060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35'
 docker_ee_gpg_fingerprint: 'DD91 1E99 5A64 A202 E859 07D6 BC14 F10B 6D08 5F96'
+
+docker_vg_name: 'docker'
+docker_pvs: '/dev/sdb'
+docker_thinpool_size: '95%VG'
+docker_thinpoolmeta_size: '1%VG'


### PR DESCRIPTION
Add a task that configures a thinpool on the specific physical volumes for Docker image and container storage.

https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/#configure-docker-with-devicemapper