### PR TITLE
Allow Docker CE variant to be specified

### DIFF
--- a/tasks/docker-engine.yml
+++ b/tasks/docker-engine.yml
@@ -14,6 +14,19 @@
 - name: Add the Docker repositories
   command: yum-config-manager --add-repo {{ docker_repo_url }}
 
+- name: Enable Docker CE stable repo
+  command: yum-config-manager --enable docker-ce-stable
+  when: "'{{ docker_edition }}' == 'docker-ce'"
+
+- name: Enable Docker CE {{ docker_ce_variant }} repo
+  command: yum-config-manager --enable docker-ce-{{ docker_ce_variant }}
+  when: "'{{ docker_edition }}' == 'docker-ce' and '{{ docker_ce_variant }}' != 'stable'"
+
+- name: Disable other Docker CE repos
+  command: yum-config-manager --disable docker-ce-{{ docker_ce_variant }}
+  with_items: "{{ docker_ce_variants }}"
+  when: "'{{ docker_edition }}' == 'docker-ce' and item != '{{ docker_ce_variant }}' and item != 'stable'"
+
 - name: Install the Docker engine
   yum:
     name: "{{ docker_edition }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,11 @@
 docker_edition: 'docker-ce'
 docker_base_url: 'https://download.docker.com/linux/centos'
 docker_repo_url: '{{ docker_base_url }}/{{ docker_edition }}.repo'
+docker_ce_variant: 'stable'
+docker_ce_variants:
+  - stable
+  - edge
+  - test
 
 docker_ce_gpg_fingerprint: '060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35'
 docker_ee_gpg_fingerprint: 'DD91 1E99 5A64 A202 E859 07D6 BC14 F10B 6D08 5F96'


### PR DESCRIPTION
Docker CE is available in three variants: stable, edge, and test. Allow the variant to be chosen.