### PR TITLE
Improve structure of variables and tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,8 @@
----
-# defaults file for docker-engine
+docker_edition: 'docker-ce'
+docker_ce_variant: 'stable'
+
+docker_vg_name: 'docker'
+docker_pvs: '/dev/sdb'
+
+docker_thinpool_size: '95%VG'
+docker_thinpoolmeta_size: '1%VG'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ docker_pvs: '/dev/sdb'
 
 docker_thinpool_size: '95%VG'
 docker_thinpoolmeta_size: '1%VG'
+
+configure_direct_lvm_storage: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-# tasks file for docker-engine
+- include: docker-engine.yml
+- include: direct-lvm-storage.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
----
 - include: docker-engine.yml
+
 - include: direct-lvm-storage.yml
+  when: configure_direct_lvm_storage

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,5 @@
-docker_edition: 'docker-ce'
 docker_base_url: 'https://download.docker.com/linux/centos'
 docker_repo_url: '{{ docker_base_url }}/{{ docker_edition }}.repo'
-docker_ce_variant: 'stable'
 docker_ce_variants:
   - stable
   - edge
@@ -9,8 +7,3 @@ docker_ce_variants:
 
 docker_ce_gpg_fingerprint: '060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35'
 docker_ee_gpg_fingerprint: 'DD91 1E99 5A64 A202 E859 07D6 BC14 F10B 6D08 5F96'
-
-docker_vg_name: 'docker'
-docker_pvs: '/dev/sdb'
-docker_thinpool_size: '95%VG'
-docker_thinpoolmeta_size: '1%VG'


### PR DESCRIPTION
Move the following vars to defaults: docker_edition, docker_ce_varaint,
docker_vg_name, docker_pvs, docker_thinpool_size, and
docker_thinpoolmeta_size. And, fill out tasks/main.yml with includes for the underlying tasks.