### PR TITLE
Copy TLS certificate files to hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,8 @@ docker_thinpool_size: '95%VG'
 docker_thinpoolmeta_size: '1%VG'
 
 configure_direct_lvm_storage: false
+
+docker_certs_dir: '/etc/docker/certs.d'
+docker_tls_ca_certificate: null
+docker_tls_certificate: null
+docker_tls_key: null

--- a/tasks/docker-certs.yml
+++ b/tasks/docker-certs.yml
@@ -8,3 +8,19 @@
   when: docker_tls_ca_certificate != None or
         docker_tls_certificate != None or
         docker_tls_key != None
+
+- name: Copy TLS certificate files to hosts
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: docker
+    mode: 0440
+  with_items:
+    - src: "{{ docker_tls_ca_certificate }}"
+      dest: /etc/docker/certs.d/ca.pem
+    - src: "{{ docker_tls_certificate }}"
+      dest: /etc/docker/certs.d/server-cert.pem
+    - src: "{{ docker_tls_key }}"
+      dest: /etc/docker/certs.d/server-key.pem
+  when: item.src != None

--- a/tasks/docker-certs.yml
+++ b/tasks/docker-certs.yml
@@ -1,0 +1,10 @@
+- name: Ensure certificates directory exists
+  file:
+    path: "{{ docker_certs_dir }}"
+    state: directory
+    owner: root
+    group: docker
+    mode: 0750
+  when: docker_tls_ca_certificate != None or
+        docker_tls_certificate != None or
+        docker_tls_key != None

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 - include: docker-engine.yml
 
+- include: docker-certs.yml
+
 - include: direct-lvm-storage.yml
   when: configure_direct_lvm_storage

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - docker-engine
+    - .


### PR DESCRIPTION
Add tasks to copy the TLS CA certificate, server certificate, and server certificate key files to the hosts. Playbooks should specify the docker_tls_ca_certificate, docker_tls_certificate, and docker_tls_key variables with the paths to the respective files.