### PR TITLE
Configure firewalld services for Docker features

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,8 @@ docker_certs_dir: '/etc/docker/certs.d'
 docker_tls_ca_certificate: null
 docker_tls_certificate: null
 docker_tls_key: null
+
+docker_remote_api: 'disabled'
+docker_overlay_networking: 'disabled'
+docker_published_ports: 'disabled'
+docker_swarm_manager: 'disabled'

--- a/files/firewalld-services/docker-engine.xml
+++ b/files/firewalld-services/docker-engine.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker Engine</short>
+  <description>The Docker daemon ports provide access to a Docker engine using the Docker API. 2375/tcp is unauthenticated. 2376/tcp will only allow connections from clients authenticated by a certificate sign by the configured CA.</description>
+  <port protocol="tcp" port="2375"/>
+  <port protocol="tcp" port="2376"/>
+</service>

--- a/files/firewalld-services/docker-overlay.xml
+++ b/files/firewalld-services/docker-overlay.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker Overlay Networking</short>
+  <description>Docker overlay networks enable communication over multiple Docker hosts. 4789/udp is the data plane (VXLAN). 7946/tcp and 7946/udp are the control plane. See https://docs.docker.com/engine/userguide/networking/ for details.</description>
+  <port protocol="udp" port="4789"/>
+  <port protocol="tcp" port="7946"/>
+  <port protocol="udp" port="7946"/>
+</service>

--- a/files/firewalld-services/docker-publish.xml
+++ b/files/firewalld-services/docker-publish.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker Published Ports</short>
+  <description>Docker services are assigned published ports in the range 30000 to 32767 by swarm managers, if they do not specify a port. Docker swarm ingress load balancing will route incoming connections on these ports to service containers. See https://docs.docker.com/engine/swarm/key-concepts/ for details.</description>
+  <port protocol="tcp" port="30000-32767"/>
+</service>

--- a/files/firewalld-services/docker-swarm.xml
+++ b/files/firewalld-services/docker-swarm.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Docker Swarm Manager</short>
+  <description>Doker swarm managers schedule services and tasks across multiple Docker engines.</description>
+  <port protocol="tcp" port="2377"/>
+</service>

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -5,3 +5,27 @@
     owner: root
     group: root
     mode: 0440
+
+- name: Docker remote API ports
+  firewalld:
+    service: docker-engine
+    state: "{{ docker_remote_api }}"
+    permanent: true
+
+- name: Docker overlay networking ports
+  firewalld:
+    service: docker-overlay
+    state: "{{ docker_overlay_networking }}"
+    permanent: true
+
+- name: Docker published ports
+  firewalld:
+    service: docker-publish
+    state: "{{ docker_published_ports }}"
+    permanent: true
+
+- name: Docker swarm manager ports
+  firewalld:
+    service: docker-swarm
+    state: "{{ docker_swarm_manager }}"
+    permanent: true

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -29,3 +29,10 @@
     service: docker-swarm
     state: "{{ docker_swarm_manager }}"
     permanent: true
+
+- name: Set masquerade on public zone
+  firewalld:
+    zone: public
+    masquerade: yes
+    state: enabled
+    permanent: true

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -1,0 +1,7 @@
+- name: Copy Docker firewalld services to hosts
+  copy:
+    src: files/firewalld-services/
+    dest: /etc/firewalld/services/
+    owner: root
+    group: root
+    mode: 0440

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,5 @@
 
 - include: direct-lvm-storage.yml
   when: configure_direct_lvm_storage
+
+- include: firewalld.yml


### PR DESCRIPTION
Add and configure firewalld services for the Docker remote API, swarm mode overlay networking, default published ports, and swarm mode manager communication.