### PR TITLE
Generate Docker daemon configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ docker_remote_api: 'disabled'
 docker_overlay_networking: 'disabled'
 docker_published_ports: 'disabled'
 docker_swarm_manager: 'disabled'
+
+dockerd_disable_legacy_registry: true

--- a/files/daemon.json.j2
+++ b/files/daemon.json.j2
@@ -1,0 +1,7 @@
+{% set dockerd_vars = {} %}
+{% for k, v in vars.items() -%}
+    {% if k.startswith('dockerd_') -%}
+        {{ dockerd_vars.update({k[8:].replace('_', '-'): v}) }}
+    {%- endif %}
+{%- endfor %}
+{{ dockerd_vars | to_nice_json }}

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,0 +1,8 @@
+# See https://docs.docker.com/engine/reference/commandline/dockerd/ for options
+- name: Generate Docker daemon configuration file
+  template:
+    src: files/daemon.json.j2
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: 0600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,3 +3,5 @@
 - include: docker-certs.yml
 
 - include: firewalld.yml
+
+- include: configuration.yml


### PR DESCRIPTION
Generate the Docker daemon configuration file at /etc/docker/daemon.json using variables prefixed with dockerd_.

The file template accumulates variables starting with dockerd_, strips off that prefix, converts _ to -, and then outputs the result as JSON.