### PR TITLE
Rename flags used for firewalld services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,9 @@ docker_tlscacert: null
 docker_tlscert: null
 docker_tlskey: null
 
-docker_remote_api: 'disabled'
-docker_overlay_networking: 'disabled'
-docker_published_ports: 'disabled'
-docker_swarm_manager: 'disabled'
+enable_remote_api: false
+enable_swarm_overlay_networks: false
+enable_swarm_service_ports: false
+enable_swarm_manager_ports: false
 
 dockerd_disable_legacy_registry: true

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,4 +1,11 @@
 # See https://docs.docker.com/engine/reference/commandline/dockerd/ for options
+- name: Set Docker socket(s) to connect to
+  set_fact:
+    dockerd_hosts:
+      - unix:///var/run/docker.sock
+      - tcp://0.0.0.0:2376
+  when: enable_remote_api and dockerd_hosts is undefined
+
 - name: Generate Docker daemon configuration file
   template:
     src: files/daemon.json.j2

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -6,6 +6,14 @@
       - tcp://0.0.0.0:2376
   when: enable_remote_api and dockerd_hosts is undefined
 
+- name: Ensure /etc/docker directory exists
+  file:
+    path: /etc/docker
+    state: directory
+    owner: root
+    group: root
+    mode: 0700
+
 - name: Generate Docker daemon configuration file
   template:
     src: files/daemon.json.j2

--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -9,25 +9,25 @@
 - name: Docker remote API ports
   firewalld:
     service: docker-engine
-    state: "{{ docker_remote_api }}"
+    state: "{{ 'enabled' if enable_remote_api else 'disabled' }}"
     permanent: true
 
 - name: Docker overlay networking ports
   firewalld:
     service: docker-overlay
-    state: "{{ docker_overlay_networking }}"
+    state: "{{ 'enabled' if enable_swarm_overlay_networks else 'disabled' }}"
     permanent: true
 
 - name: Docker published ports
   firewalld:
     service: docker-publish
-    state: "{{ docker_published_ports }}"
+    state: "{{ 'enabled' if enable_swarm_service_ports else 'disabled' }}"
     permanent: true
 
 - name: Docker swarm manager ports
   firewalld:
     service: docker-swarm
-    state: "{{ docker_swarm_manager }}"
+    state: "{{ 'enabled' if enable_swarm_manager_ports else 'disabled' }}"
     permanent: true
 
 - name: Set masquerade on public zone


### PR DESCRIPTION
Rename the variables used for enabling or disabling firewalld services
into true/false boolean flags. This separates them from the underlying
enabled/disabled values, and makes them usable in other situations.