### PR TITLE
Set docker_certs_dir to /etc/docker/certs.d

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 docker_edition: 'docker-ce'
 docker_ce_variant: 'stable'
 
-docker_certs_dir: '~/.docker'
+docker_certs_dir: '/etc/docker/certs.d'
 docker_tlscacert: null
 docker_tlscert: null
 docker_tlskey: null


### PR DESCRIPTION
Change the default value of docker_certs_dir from ~/.docker to
/etc/docker/certs.d. The previous value makes more sense for clients
than for servers.

Resolves #20